### PR TITLE
Add a number of citizens juries facilitated by Shared Future

### DIFF
--- a/data/raw/assemblies/la-bar-2021-climate-jury.yaml
+++ b/data/raw/assemblies/la-bar-2021-climate-jury.yaml
@@ -1,0 +1,18 @@
+authority_type: Local Authority
+local_authority_code: BAR
+org_name: Borough of Barrow-in-Furness
+url: https://sharedfuturecic.org.uk/reports/the-furness-citizens-jury-on-climate-change/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Citizens-Jury-Climate-Furness-Cumbria-2022.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2021
+number_participants: 25
+assembly_description: The Furness Citizens’ Jury on Climate Change saw
+  25 citizens come together to consider what should happen in the Furness
+  area to address the emergency of climate change. The jury met for ten
+  Tuesday evening sessions over a three-month period, via Zoom, and heard
+  from a range of expert opinions before reaching a series of
+  recommendations for the council.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/la-bbd-2022-climate-jury.yaml
+++ b/data/raw/assemblies/la-bbd-2022-climate-jury.yaml
@@ -1,0 +1,18 @@
+authority_type: Local Authority
+local_authority_code: BBD
+org_name: Blackburn with Darwen Borough Council
+url: https://sharedfuturecic.org.uk/reports/the-blackburn-with-darwen-peoples-jury-on-the-climate-change-crisis/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Peoples-Jury-Climate-Blackburn-2022.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2022
+number_participants: 26
+assembly_description: The People’s Jury on Climate Change was run
+  on behalf of Blackburn with Darwen Council, to give residents a
+  say on how to tackle the issues relating to climate change in
+  their borough. After 30 hours of deliberation, the jury produced
+  a set of 15 recommendations on how to address the climate emergency
+  in the Blackburn with Darwen area.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/la-cop-2021-climate-panel.yaml
+++ b/data/raw/assemblies/la-cop-2021-climate-panel.yaml
@@ -1,0 +1,18 @@
+authority_type: Local Authority
+local_authority_code: COP
+org_name: Copeland Borough Council
+url: https://sharedfuturecic.org.uk/reports/the-copeland-peoples-panel-on-climate-change-july-september-2021/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/The-peoples-climate-panel-Copeland-2021.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2021
+number_participants: 30
+assembly_description: The Copeland People’s Panel on Climate Change ran
+  in 2021, as part of the National Lottery funded Zero Carbon Cumbria
+  Partnership, to identify the ideas, strategies and actions needed to
+  respond to the climate crisis in the Copeland area. The panel of 30
+  Copeland residents met between eight and ten times, over Zoom, and
+  produced 22 recommendations.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/la-pre-2024-climate-jury.yaml
+++ b/data/raw/assemblies/la-pre-2024-climate-jury.yaml
@@ -1,0 +1,18 @@
+authority_type: Local Authority
+local_authority_code: PRE
+org_name: Preston City Council
+url: https://sharedfuturecic.org.uk/reports/preston-peoples-climate-jury/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/Preston-Peoples-Jury-on-Climate-Change-Final.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2024
+number_participants: 27
+assembly_description: In early 2024, 27 Preston District residents met
+  to consider how Preston stakeholders could work together to address
+  the opportunities and challenges of climate change in a way that is
+  fair to everyone. After 30 hours of deliberation, the Jury produced
+  24 recommendations covering food, housing and buildings, transport,
+  and other climate change-related topics.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/la-wmca-2016-mental-health-jury.yaml
+++ b/data/raw/assemblies/la-wmca-2016-mental-health-jury.yaml
@@ -1,0 +1,17 @@
+authority_type: Local Authority
+local_authority_code: WMCA
+org_name: West Midlands Combined Authority
+url: https://sharedfuturecic.org.uk/reports/the-west-midlands-mental-health-commission-citizens-jury/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Mental-Health-Commission-West-Midlands-2016.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2016
+number_participants: 15
+assembly_description: In spring 2016, fifteen residents of the West Midlands
+  with lived experience of mental health problems, met for eight sessions of
+  deliberation, to produce a set of recommendations for the West Midlands
+  Mental Health Commission on how public services can be transformed in the
+  context of a devolution deal for mental health and well-being.
+thematic_grouping: Health and Care
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/org-bude-climate-partnership-2023-climate-jury.yaml
+++ b/data/raw/assemblies/org-bude-climate-partnership-2023-climate-jury.yaml
@@ -1,0 +1,18 @@
+authority_type: Other
+local_authority_code:
+org_name: Bude Climate Partnership
+url: https://sharedfuturecic.org.uk/reports/bude-area-community-jury-on-climate-change/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/The-community-climate-Jury-Bude-2023.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2023
+number_participants: 53
+assembly_description: The Bude Area Community Jury on Climate Change
+  brought together 34 citizens aged 16 to 86 from across the wider
+  Bude area to consider how the community could respond to a changing
+  climate. The jury produced 11 principles for future decision making
+  on sea level rise, and 29 recommendations covering sea level rise,
+  awareness raising, and other climate change-related topics.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/org-kendal-town-council-2020-climate-assembly.yaml
+++ b/data/raw/assemblies/org-kendal-town-council-2020-climate-assembly.yaml
@@ -1,8 +1,8 @@
-authority_type: Other
+authority_type: Town Council
 local_authority_code:
 org_name: Kendal Town Council
 url: https://www.kendalclimatejury.org
-report_pdf_url: https://www.kendalclimatejury.org/wp-content/uploads/2021/01/KendalClimateChangeJuryRecomendations.pdf
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Climate-Jury-Kendal-2020.pdf
 faciliator: Shared Future
 assembly_status: Finished
 assembly_year: 2020

--- a/data/raw/assemblies/org-northern-housing-consortium-2021-climate-jury.yaml
+++ b/data/raw/assemblies/org-northern-housing-consortium-2021-climate-jury.yaml
@@ -1,0 +1,16 @@
+authority_type: Other
+local_authority_code:
+org_name: Northern Housing Consortium
+url: https://sharedfuturecic.org.uk/reports/the-social-housing-tenants-climate-jury-report/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Social-Housing-Tenants-Climate-Jury-2021.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2021
+number_participants: 30
+assembly_description: The Social Housing Tenants’ Climate Jury saw
+  30 social housing tenants from across the North meet online over
+  10 weeks between July and September 2021, to explore tenants’
+  views and needs around retrofit and low carbon heating technologies.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/org-scottish-health-council-2018-decision-making-jury.yaml
+++ b/data/raw/assemblies/org-scottish-health-council-2018-decision-making-jury.yaml
@@ -1,0 +1,16 @@
+authority_type: Other
+local_authority_code:
+org_name: Scottish Health Council
+url: https://sharedfuturecic.org.uk/reports/realistic-medicine-our-voice-citizens-jury-on-shared-decision-making/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Health-and-social-care-Scotland-2019.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2018
+number_participants: 24
+assembly_description: In the ‘Our Voice’ Citizens Jury on
+  Shared Decision-making, a diverse group of 24 Scottish
+  citizens gathered over three days to make recommendations
+  on shared decision-making in health and social care.
+thematic_grouping: Health and Care
+source_notes:
+data_source: mySocietySearch

--- a/data/raw/assemblies/org-shipley-town-council-2023-climate-jury.yaml
+++ b/data/raw/assemblies/org-shipley-town-council-2023-climate-jury.yaml
@@ -1,0 +1,20 @@
+authority_type: Town Council
+local_authority_code:
+org_name: Shipley Town Council
+url: https://sharedfuturecic.org.uk/reports/shipleys-citizens-report-on-climate-change/
+report_pdf_url: https://sharedfuturecic.org.uk/wp-content/uploads/2024/04/Citizens-Jury-on-climate-Shipley-2023.pdf
+faciliator: Shared Future
+assembly_status: Finished
+assembly_year: 2023
+number_participants: 25
+assembly_description: The Shipley Town Council Citizens’ Jury, commissioned
+  by Shipley Town Council with support from a National Lottery ‘Together for
+  Our Planet’ grant, brought together 25 residents to explore how local
+  stakeholders could work together to limit climate change and its impacts
+  while protecting their environment and health. The juery produced seven
+  headline recommendations including building retrofit and skills development,
+  the creation of a ‘pollinator corridor’ of private and public green spaces,
+  and giving greater priority to pedestrian and people-powered transport.
+thematic_grouping: Climate Assembly
+source_notes:
+data_source: mySocietySearch

--- a/src/citizen_assembly_data/models.py
+++ b/src/citizen_assembly_data/models.py
@@ -27,6 +27,7 @@ OptionalUrl = Url | None
 class AuthorityType(str, Enum):
     LOCAL_AUTHORITY = "Local Authority"
     NATION = "Nation"
+    TOWN_COUNCIL = "Town Council"
     OTHER = "Other"
     NHS = "NHS"
 


### PR DESCRIPTION
As well as adding a handful of new assemblies/juries, this introduces a new `authority_type` of `Town Council`.